### PR TITLE
Add lists to configfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Please follow this structure:
 
 `configfile init` Initialize *configfile* on the current user session.
 
-### Deploy configuration files
+### List of modules
+
+`configfile modules` Display a list of all modules available via **Configfile**
+
+### Deploy configuration files (module)
 
 `configfile deploy [moduleName...]` Deploy the configuration files for the given module name.
+
+### List of scripts
+
+`configfile scripts` Display a list of all scripts available via **Configfile**
 
 ### Run script
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const program = require('commander')
 const fs = require('fs')
 const path = require('path')
 
-const { initCommand, runCommand, deployCommand } = require('./src/commands')
+const { initCommand, runCommand, deployCommand, scriptsCommand } = require('./src/commands')
 
 const { ConfigService } = require('./src/services/config')
 const { FileService } = require('./src/services/file')
@@ -25,6 +25,12 @@ program
   .description('activate configfiles on user session.')
   .option('-f, --force', 'force parameters file overwrite.')
   .action(initCommand(configService))
+
+
+program
+  .command('scripts')
+  .description('list all custom configuration scripts available.')
+  .action(scriptsCommand(fileService))
 
 program
   .command('run <name>')

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const program = require('commander')
 const fs = require('fs')
 const path = require('path')
 
-const { initCommand, runCommand, deployCommand, scriptsCommand } = require('./src/commands')
+const { initCommand, runCommand, deployCommand, scriptsCommand, modulesCommand } = require('./src/commands')
 
 const { ConfigService } = require('./src/services/config')
 const { FileService } = require('./src/services/file')
@@ -26,7 +26,6 @@ program
   .option('-f, --force', 'force parameters file overwrite.')
   .action(initCommand(configService))
 
-
 program
   .command('scripts')
   .description('list all custom configuration scripts available.')
@@ -37,6 +36,11 @@ program
   .alias('r')
   .description('run custom configuration scripts.')
   .action(runCommand(configService, fileService))
+
+program
+  .command('modules')
+  .description('list all custom configuration scripts available.')
+  .action(modulesCommand(fileService))
 
 program
   .command('deploy [modules...]')

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,10 +2,12 @@ const initCommand = require('./init/init.command')
 const runCommand = require('./run/run.command')
 const deployCommand = require('./deploy/deploy.command')
 const scriptsCommand = require('./scripts.commande')
+const modulesCommand = require('./modules.commande')
 
 module.exports = exports = {
   initCommand,
   runCommand,
   deployCommand,
-  scriptsCommand
+  scriptsCommand,
+  modulesCommand
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,9 +1,11 @@
 const initCommand = require('./init/init.command')
 const runCommand = require('./run/run.command')
 const deployCommand = require('./deploy/deploy.command')
+const scriptsCommand = require('./scripts.commande')
 
 module.exports = exports = {
   initCommand,
   runCommand,
-  deployCommand
+  deployCommand,
+  scriptsCommand
 }

--- a/src/modules.commande.js
+++ b/src/modules.commande.js
@@ -1,0 +1,16 @@
+const { LogUtils } = require('./shared/log.utils')
+
+module.exports = exports = fileService => () => {
+  const modules = fileService.modules
+
+  if (modules.length < 1) {
+    LogUtils.log({ type: 'info', message: `No module found.` })
+    return
+  }
+
+  LogUtils.log({ message: `${modules.length} module(s) found.` })
+
+  for (const { module: name } of modules) {
+    LogUtils.log({ message: `- ${name}` })
+  }
+}

--- a/src/scripts.commande.js
+++ b/src/scripts.commande.js
@@ -10,7 +10,7 @@ module.exports = exports = fileService => () => {
 
   LogUtils.log({ message: `${scripts.length} script(s) found.` })
 
-  for (const [index, { script }] of scripts.entries()) {
+  for (const { script } of scripts) {
     LogUtils.log({ message: `- ${script}` })
   }
 }

--- a/src/scripts.commande.js
+++ b/src/scripts.commande.js
@@ -1,0 +1,16 @@
+const { LogUtils } = require('./shared/log.utils')
+
+module.exports = exports = fileService => () => {
+  const scripts = fileService.scripts
+
+  if (scripts.length < 1) {
+    LogUtils.log({ type: 'info', message: `No scripts found.` })
+    return
+  }
+
+  LogUtils.log({ message: `${scripts.length} script(s) found.` })
+
+  for (const [index, { script }] of scripts.entries()) {
+    LogUtils.log({ message: `- ${script}` })
+  }
+}

--- a/src/shared/log.utils.js
+++ b/src/shared/log.utils.js
@@ -56,6 +56,10 @@ class LogUtils {
 
     console.log(message)
   }
+
+  static addBlanckLine() {
+    console.log('')
+  }
 }
 
 module.exports = exports = {


### PR DESCRIPTION
Add two commands to list modules and scripts. 

The goal is to : 
1. give a reminder
2. allow to see if configfile factors configuration files and custom scripts 

The two commands are : `configfile modules` and `configfile scripts`. See modifications in `README.md`

Fix #7 