### PR TITLE
Update settings file format in modules

### DIFF
--- a/src/services/file/file.service.js
+++ b/src/services/file/file.service.js
@@ -72,8 +72,8 @@ class FileService {
       .map(element => {
         element.settings = element.settings
           .map(file => ({
-            source: path.resolve(element.path, file['filename']),
-            target: path.resolve(file['target-path'].replace('~', process.env.HOME)),
+            source: path.resolve(element.path, file['source_path']),
+            target: path.resolve(file['target_path'].replace('~', process.env.HOME)),
             global: file.global
           }))
 


### PR DESCRIPTION
Update JSON format for `settings.json` inside of modules. 

This change is necessary to make configuration of **configfile** easier and more obvious:

- `filename` attribute become `source_path` because we can use folder as path, not only file
- `target-path` attribute become `target_path` for coherence with `~/.configfiles`