### PR TITLE
Fix modules scripts error handling

### DIFF
--- a/src/modules.command.js
+++ b/src/modules.command.js
@@ -1,7 +1,19 @@
 const { LogUtils } = require('./shared/log.utils')
 
+const { ConfigurationFileNotExist } = require('./services/config')
+
 module.exports = exports = fileService => () => {
-  const modules = fileService.modules
+  let modules = []
+
+  try {
+    modules = fileService.modules
+  } catch (e) {
+    if (e instanceof ConfigurationFileNotExist) {
+      LogUtils.log({ message: 'Unable to load modules without knowing where are stored the data.' })
+      LogUtils.log({ type: 'error', message: 'No configuration file. You need to run the init command before.' })
+      return
+    }
+  }
 
   if (modules.length < 1) {
     LogUtils.log({ type: 'info', message: `No module found.` })

--- a/src/scripts.command.js
+++ b/src/scripts.command.js
@@ -1,7 +1,19 @@
 const { LogUtils } = require('./shared/log.utils')
 
+const { ConfigurationFileNotExist } = require('./services/config')
+
 module.exports = exports = fileService => () => {
-  const scripts = fileService.scripts
+  let scripts = []
+
+  try {
+    scripts = fileService.scripts
+  } catch (e) {
+    if (e instanceof ConfigurationFileNotExist) {
+      LogUtils.log({ message: 'Unable to load scripts without knowing where are stored the data.' })
+      LogUtils.log({ type: 'error', message: 'No configuration file. You need to run the init command before.' })
+      return
+    }
+  }
 
   if (scripts.length < 1) {
     LogUtils.log({ type: 'info', message: `No scripts found.` })


### PR DESCRIPTION
Some errors on `configfile scripts` and `configfile modules` wasn't catch correctly:

When user execute one of the two commands without having `~/.configfilerc`, `ConfigurationFileNotExist` are thrown.
