### PR TITLE
Rename preexisting file at deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Adopte a git like command style: `configfile run` => `configfile scritps run`.
+- Create a "saved version" if preexisting file exist when user deploy a module.
 
 ## [0.2.1] - 2017-10-13
 ### Fixed

--- a/src/services/file/file.service.js
+++ b/src/services/file/file.service.js
@@ -150,7 +150,11 @@ class FileService {
               return FsUtils.rename(file.target, `${file.target}.old`)
             }
           })
-          .catch(error => console.log(error))
+          .catch(error => {
+            if (error.code !== 'ENOENT') { // No file exist at file.target
+              throw error
+            }
+          })
           .then(_ => FsUtils.symlink(file.source, file.target))
           .catch(error => {
             if (error.code !== 'EEXIST') {

--- a/src/services/file/file.service.js
+++ b/src/services/file/file.service.js
@@ -136,7 +136,7 @@ class FileService {
       const linkCreation = files
         .map(file => Promise.resolve()
           .then(_ => {
-            if (FsUtils.fileExist(file.target)) {
+            if (FsUtils.fileExist(file.target, false)) {
               return FsUtils.rename(file.target, `${file.target}.old`)
             }
           })

--- a/src/services/file/file.service.js
+++ b/src/services/file/file.service.js
@@ -134,7 +134,13 @@ class FileService {
 
     return Promise.all(dirCreation).then(() => {
       const linkCreation = files
-        .map(file => FsUtils.symlink(file.source, file.target)
+        .map(file => Promise.resolve()
+          .then(_ => {
+            if (FsUtils.fileExist(file.target)) {
+              return FsUtils.rename(file.target, `${file.target}.old`)
+            }
+          })
+          .then(_ => FsUtils.symlink(file.source, file.target))
           .catch(error => {
             if (error.code !== 'EEXIST') {
               throw error

--- a/src/shared/utils/fs.utils.js
+++ b/src/shared/utils/fs.utils.js
@@ -23,6 +23,10 @@ class FsUtils {
     return util.promisify(fs.mkdir)
   }
 
+  static get rename() {
+    return util.promisify(fs.rename)
+  }
+
   static fileExist(filename = '') {
     try {
       fs.accessSync(filename)

--- a/src/shared/utils/fs.utils.js
+++ b/src/shared/utils/fs.utils.js
@@ -29,7 +29,7 @@ class FsUtils {
 
   static fileExist(filename = '') {
     try {
-      fs.accessSync(filename)
+      fs.lstatSync(filename)
     } catch (e) {
       return false
     }

--- a/src/shared/utils/fs.utils.js
+++ b/src/shared/utils/fs.utils.js
@@ -27,9 +27,13 @@ class FsUtils {
     return util.promisify(fs.rename)
   }
 
-  static fileExist(filename = '') {
+  static fileExist(filename = '', followLink = true) {
     try {
-      fs.lstatSync(filename)
+      if (followLink) {
+        fs.accessSync(filename)
+      } else {
+        fs.lstatSync(filename)
+      }
     } catch (e) {
       return false
     }

--- a/src/shared/utils/fs.utils.js
+++ b/src/shared/utils/fs.utils.js
@@ -27,6 +27,18 @@ class FsUtils {
     return util.promisify(fs.rename)
   }
 
+  static get lstat() {
+    return util.promisify(fs.lstat)
+  }
+
+  static get readlink() {
+    return util.promisify(fs.readlink)
+  }
+
+  static get unlink() {
+    return util.promisify(fs.unlink)
+  }
+
   static fileExist(filename = '', followLink = true) {
     try {
       if (followLink) {


### PR DESCRIPTION
### Summary

At deployment time, if a "preexisting file" exist where configfile need to deploy a file it save as `filename.old` before deploying.

Close #33 