### PR TITLE
Release/0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2017-11-15
 ### Added
 - A contribution guide (CONTRIBUTING.md) to help new contributors.
 - The local deployment of configuration file. (`-l` on `modules deploy`)
@@ -44,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The README file to give first information on the project (installation, usage, etc.).
 
 [Unreleased]: https://github.com/Mindsers/configfile/tree/develop
+[0.3.0]: https://github.com/Mindsers/configfile/tree/0.3.0
 [0.2.1]: https://github.com/Mindsers/configfile/tree/0.2.1
 [0.2.0]: https://github.com/Mindsers/configfile/tree/0.2.0
 [0.1.1]: https://github.com/Mindsers/configfile/tree/0.1.1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Please follow this structure:
     /scriptfile.sh
 ```
 
+## Installation
+
+To install *Configfile*, you need to use NPM or Yarn.
+
+```bash
+npm install -g configfile@latest
+```
+
 ## Usage
 
 - `configfile init` or `configfile i`: Initialize *configfile* on the current user session.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please follow this structure:
 To install *Configfile*, you need to use NPM or Yarn.
 
 ```bash
-npm install -g configfile@latest
+yarn global add configfile@latest
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configfile",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Personal config files manager",
   "main": "index.js",
   "repository": "github.com:Mindsers/configfile.git",


### PR DESCRIPTION
### Summary

New version 👍 

### Added
- A contribution guide (CONTRIBUTING.md) to help new contributors.
- The local deployment of configuration file. (`-l` on `modules deploy`)

### Changed
- Adopte a git like command style: `configfile run` => `configfile scritps run`.
- Create a "saved version" if preexisting file exist when user deploy a module.
- Do not indentify the modules to deploy cause the deployment of all available modules. User authorization is required.
