### PR TITLE
Fix script stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Git URL verification in `init` command is less strict. ([#48](https://github.com/Mindsers/configfile/issues/48))
+- Script standard outputs are correctly displayed ([!57](https://github.com/Mindsers/configfile/pull/57), [#13](https://github.com/Mindsers/configfile/issues/13))
 
 ## [0.3.1] - 2018-08-05
 ### Fixed

--- a/bin/configfile-scripts.js
+++ b/bin/configfile-scripts.js
@@ -25,7 +25,7 @@ const {
 
   cli.provide({ identity: OPTION_PATH_FILE_TOKEN, useValue: getOptionsFilePath() })
   cli.provide(FileService, [ConfigService, MessageService])
-  cli.provide(ExecService, [MessageService])
+  cli.provide(ExecService)
   cli.provide(ConfigService, [OPTION_PATH_FILE_TOKEN])
 
   cli.start()

--- a/src/services/exec.service.js
+++ b/src/services/exec.service.js
@@ -2,10 +2,6 @@ import { FsUtils, ProcessUtils } from '../shared/utils'
 import { ScriptNotExist, BadScriptPermission } from '../shared/errors'
 
 export class ExecService {
-  constructor(messageService) {
-    this.messageService = messageService
-  }
-
   async runScript(script) {
     if (script == null) {
       throw new ScriptNotExist(script.script)
@@ -13,17 +9,8 @@ export class ExecService {
 
     await FsUtils.chmod(script.path, '0700')
 
-    const child = ProcessUtils.execFile(script.path)
-
-    child.stdout.on('data', data => {
-      this.messageService.printRawText(data.trim())
-    })
-    child.stderr.on('data', data => {
-      this.messageService.printRawError(data.trim())
-    })
-
     try {
-      return await child.toPromise()
+      return await ProcessUtils.spawn(script.path)
     } catch (error) {
       if (error.code === 'EACCES') {
         throw new BadScriptPermission(script.script)

--- a/src/services/message.service.js
+++ b/src/services/message.service.js
@@ -59,14 +59,6 @@ export class MessageService {
     this.print('')
   }
 
-  printRawText(text) {
-    this.stdout.write(text)
-  }
-
-  printRawError(text) {
-    this.stderr.write(text)
-  }
-
   _useBuilder(stylePrefix, styleText, defaultPrefix) {
     return (prefix, ...texts) => {
       let fullText = `${styleText(prefix)}\n`

--- a/src/shared/utils/process.utils.js
+++ b/src/shared/utils/process.utils.js
@@ -1,16 +1,12 @@
-import childProcess from 'child_process'
+import { spawn } from 'child_process'
 
 export class ProcessUtils {
-  static execFile(filename) {
-    const child = childProcess.spawn(filename, [], { stdio: 'inherit' })
+  static spawn(filename) {
+    return new Promise((resolve, reject) => {
+      const child = spawn(filename, [], { stdio: 'inherit' })
 
-    return {
-      stdout: child.stdout,
-      stderr: child.stderr,
-      toPromise: () => new Promise((resolve, reject) => {
-        child.addListener('error', reject)
-        child.addListener('exit', resolve)
-      })
-    }
+      child.addListener('error', reject)
+      child.addListener('exit', resolve)
+    })
   }
 }

--- a/src/shared/utils/process.utils.js
+++ b/src/shared/utils/process.utils.js
@@ -2,7 +2,7 @@ import childProcess from 'child_process'
 
 export class ProcessUtils {
   static execFile(filename) {
-    const child = childProcess.execFile(filename)
+    const child = childProcess.spawn(filename, [], { stdio: 'inherit' })
 
     return {
       stdout: child.stdout,


### PR DESCRIPTION
Fix standard output issues for "custom scripts" due to #57 and the issues described in #13.

### Other Informations

Running a script now create a child process of *Configfile* where the script is running. All the `sdtios` of the script is linked to the *Configfile* ones as if it was standard outputs of the `configfile` command.
